### PR TITLE
Revamp Minecraft survival builds and Bed Wars guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Minecraft Survival Builds & Bed Wars Guide</title>
+    <meta
+      name="description"
+      content="Learn practical Minecraft survival builds and a Bed Wars strategy that carries you from the opening rush to the final fight."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="hero">
+      <div class="hero__wrap">
+        <p class="hero__eyebrow">Minecraft playbook</p>
+        <h1>Build smarter. Fight harder.</h1>
+        <p class="hero__lead">
+          A bite-sized hub of survival builds, redstone upgrades, and a Bed Wars
+          gameplan. Perfect for new players or friends who want quick wins on a
+          Realm or Hypixel.
+        </p>
+        <nav class="hero__nav">
+          <a href="#starter-builds">Survival builds</a>
+          <a href="#automation">Automation</a>
+          <a href="#bedwars">Bed Wars strategy</a>
+          <a href="#practice">Practice drills</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section id="starter-builds" class="panel">
+        <h2>Essential survival builds</h2>
+        <p class="panel__intro">
+          Start here on a fresh world. Each build fits in a compact area and can
+          be finished in the first few in-game days.
+        </p>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Starter core base</h3>
+            <p>
+              A layered 9×9 base with storage, smelting, and a crop patch.
+              Construct the base in three rings so upgrades are easy.
+            </p>
+            <dl class="card__list">
+              <div>
+                <dt>Resources</dt>
+                <dd>64 logs, 96 planks, 12 glass panes, 8 lanterns</dd>
+              </div>
+              <div>
+                <dt>Build steps</dt>
+                <dd>
+                  Lay the ring, set 4-high pillars, cap with stair roof, then
+                  carve storage alcoves inside the walls.
+                </dd>
+              </div>
+            </dl>
+          </article>
+          <article class="card">
+            <h3>Adventurer tower</h3>
+            <p>
+              A slim tower with floor-by-floor specialisation: lookout, map
+              room, enchanting, and portal access.
+            </p>
+            <dl class="card__list">
+              <div>
+                <dt>Resources</dt>
+                <dd>Stone bricks, spruce stairs, 2 campfires, lectern, books</dd>
+              </div>
+              <div>
+                <dt>Build steps</dt>
+                <dd>
+                  Stack 5×5 floors with stair corners, add campfire chimney, and
+                  hang lanterns on chains for warm lighting.
+                </dd>
+              </div>
+            </dl>
+          </article>
+          <article class="card">
+            <h3>Safe mine entrance</h3>
+            <p>
+              Keeps mobs away from your main staircase and gives quick access to
+              strip mines and rails.
+            </p>
+            <dl class="card__list">
+              <div>
+                <dt>Resources</dt>
+                <dd>Fence gates, stone bricks, mossy accents, barrels</dd>
+              </div>
+              <div>
+                <dt>Build steps</dt>
+                <dd>
+                  Sink the entrance two blocks, ring it with fence gates, add a
+                  trapdoor ceiling, and stash rails and fuel in wall barrels.
+                </dd>
+              </div>
+            </dl>
+          </article>
+        </div>
+      </section>
+
+      <section id="automation" class="panel">
+        <h2>Redstone &amp; resource automation</h2>
+        <p class="panel__intro">
+          Once you gear up, these farms sustain you without endless grinding.
+          Keep an eye on mob caps and villager gossip to keep them running.
+        </p>
+        <div class="stack">
+          <article class="feature">
+            <div>
+              <h3>Villager crop farm</h3>
+              <p>
+                Two villagers handle planting and collection. Fence the farm and
+                seal it with trapdoors to stop raids and pillagers.
+              </p>
+            </div>
+            <ul>
+              <li>8×8 tilled plot with waterlogged stairs in the centre.</li>
+              <li>
+                Farmer tosses crops to a "hungry" villager who feeds a hopper
+                minecart.
+              </li>
+              <li>Place a composter near the farmer so they keep working.</li>
+            </ul>
+          </article>
+          <article class="feature">
+            <div>
+              <h3>Iron golem foundry</h3>
+              <p>
+                Three villagers and a zombie spawn golems that drop into lava
+                for quick early armour.
+              </p>
+            </div>
+            <ul>
+              <li>Bed cells 20 blocks above ground to reduce random spawns.</li>
+              <li>
+                Zombie scares villagers on a daylight clock to keep spawning
+                consistent.
+              </li>
+              <li>Hopper minecart under the kill box keeps collection safe.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="bedwars" class="panel">
+        <h2>Bed Wars win condition</h2>
+        <p class="panel__intro">
+          Play each stage with intent: defend early, control mid, and collapse
+          on beds together.
+        </p>
+        <div class="timeline">
+          <article>
+            <h3>Opening (0:00 – 1:30)</h3>
+            <ul>
+              <li>Hotkey wool, grab 48 blocks, and layer wool + wood.</li>
+              <li>
+                First teammate grabs diamonds. Buy protection I before iron
+                armour.
+              </li>
+              <li>Second teammate rushes side team to slow their bridge.</li>
+            </ul>
+          </article>
+          <article>
+            <h3>Mid game (1:30 – 6:00)</h3>
+            <ul>
+              <li>Rotate to mid with shears and fireballs; deny invis rushes.</li>
+              <li>
+                Mix roles: base anchor watches traps, slayer harasses bridges,
+                scout secures emerald loops.
+              </li>
+              <li>
+                Prioritise sharpness, prot II, and heal pool in that order.
+              </li>
+            </ul>
+          </article>
+          <article>
+            <h3>End game (after beds fall)</h3>
+            <ul>
+              <li>
+                Invisibility + jump + pearl is the knockout combo—drink out of
+                sight.
+              </li>
+              <li>Force split pushes; never take 1v2s without a trap advantage.</li>
+              <li>Carry gaps and magic milk to ignore alarm trap reveals.</li>
+            </ul>
+          </article>
+        </div>
+        <aside class="callout">
+          <h3>Communication cues</h3>
+          <p>
+            Call emerald timers (“two in 15!”), bed breaks, and trap triggers in
+            short phrases. Staying vocal prevents surprise rushes.
+          </p>
+        </aside>
+      </section>
+
+      <section id="practice" class="panel panel--accent">
+        <h2>Practice drills before you queue</h2>
+        <div class="practice-grid">
+          <article>
+            <h3>Speed bridge reps</h3>
+            <p>
+              Spend five minutes in a private world aiming for 64-block
+              side-bridges without falling. Use F3+B to ensure crosshair
+              alignment.
+            </p>
+          </article>
+          <article>
+            <h3>Clutch training</h3>
+            <p>
+              Drop from a 12-block tower and practice ladder, water, and block
+              clutches. Rotate hotbar slots until the motions are muscle memory.
+            </p>
+          </article>
+          <article>
+            <h3>Combat warm-up</h3>
+            <p>
+              Duel a friend or bot for five rounds of rod + sword hits. Focus on
+              W-tapping to reset sprint and keep combos rolling.
+            </p>
+          </article>
+        </div>
+        <p class="panel__footer">
+          Save this page to your phone or share with your duo so everyone plays
+          from the same strat sheet.
+        </p>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>
+        Crafted for Minecraft survivalists and Bed Wars teammates looking for a
+        quick edge. Share feedback on GitHub if you try the builds!
+      </p>
+    </footer>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,316 @@
+:root {
+  --bg: #0e1221;
+  --bg-light: #161c30;
+  --panel: #11172a;
+  --accent: #4fc3f7;
+  --accent-soft: rgba(79, 195, 247, 0.16);
+  --accent-strong: #00b3ff;
+  --text: #f2f5ff;
+  --muted: #b3c0e0;
+  --shadow: rgba(4, 9, 20, 0.4);
+  font-family: 'Segoe UI', Roboto, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(79, 195, 247, 0.14), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(76, 175, 80, 0.12), transparent 55%),
+    var(--bg);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 0;
+  background: var(--accent);
+  color: var(--bg);
+  padding: 0.75rem 1rem;
+  border-radius: 0 0 0.75rem 0.75rem;
+  z-index: 10;
+  font-weight: 600;
+}
+
+.skip-link:focus {
+  left: 1rem;
+}
+
+.hero {
+  padding: 4.5rem 1.5rem 3rem;
+  background: linear-gradient(160deg, rgba(24, 32, 54, 0.9), rgba(14, 18, 32, 0.9));
+  border-bottom: 1px solid rgba(79, 195, 247, 0.2);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(79, 195, 247, 0.2), transparent 55%),
+    radial-gradient(circle at 80% 80%, rgba(13, 71, 161, 0.25), transparent 60%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.hero__wrap {
+  position: relative;
+  max-width: 960px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: var(--accent);
+  font-size: 0.85rem;
+  margin: 0 0 1rem;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.75rem, 5vw, 3.9rem);
+  letter-spacing: 0.04em;
+}
+
+.hero__lead {
+  margin: 1rem auto 2rem;
+  max-width: 640px;
+  line-height: 1.7;
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+.hero__nav {
+  display: inline-flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.hero__nav a {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(79, 195, 247, 0.35);
+  color: var(--text);
+  text-decoration: none;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero__nav a:hover,
+.hero__nav a:focus {
+  background: rgba(79, 195, 247, 0.16);
+  transform: translateY(-3px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+main {
+  width: min(1100px, 92vw);
+  margin: -2.5rem auto 0;
+  padding-bottom: 4rem;
+  display: grid;
+  gap: 2.5rem;
+  flex: 1 0 auto;
+}
+
+.panel {
+  background: linear-gradient(145deg, rgba(16, 23, 43, 0.95), rgba(13, 20, 36, 0.95));
+  padding: 2.75rem 2.5rem;
+  border-radius: 28px;
+  border: 1px solid rgba(79, 195, 247, 0.14);
+  box-shadow: 0 24px 45px var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(79, 195, 247, 0.22), transparent 60%);
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.panel > * {
+  position: relative;
+}
+
+.panel h2 {
+  margin-top: 0;
+  font-size: clamp(2rem, 4vw, 2.4rem);
+}
+
+.panel__intro {
+  color: var(--muted);
+  margin-bottom: 2rem;
+  line-height: 1.7;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: rgba(11, 18, 33, 0.92);
+  border-radius: 20px;
+  padding: 1.75rem;
+  border: 1px solid rgba(79, 195, 247, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.35);
+}
+
+.card__list {
+  margin: 0;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.card__list dt {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.card__list dd {
+  margin: 0.2rem 0 0;
+  line-height: 1.6;
+}
+
+.stack {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.feature {
+  background: rgba(8, 14, 27, 0.88);
+  border-radius: 20px;
+  padding: 1.75rem 2rem;
+  border: 1px solid rgba(79, 195, 247, 0.18);
+  display: grid;
+  gap: 1rem;
+  align-items: start;
+}
+
+.feature h3 {
+  margin: 0 0 0.35rem;
+}
+
+.feature p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.feature ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  line-height: 1.6;
+}
+
+.timeline {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-bottom: 2rem;
+}
+
+.timeline article {
+  background: rgba(9, 16, 30, 0.92);
+  border-radius: 18px;
+  padding: 1.5rem;
+  border: 1px solid rgba(79, 195, 247, 0.16);
+}
+
+.timeline h3 {
+  margin: 0 0 0.75rem;
+}
+
+.timeline ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  line-height: 1.6;
+}
+
+.callout {
+  background: var(--accent-soft);
+  border-left: 4px solid var(--accent-strong);
+  padding: 1.5rem 1.75rem;
+  border-radius: 16px;
+  color: var(--text);
+}
+
+.callout h3 {
+  margin-top: 0;
+}
+
+.panel--accent {
+  background: linear-gradient(145deg, rgba(17, 27, 54, 0.95), rgba(13, 28, 44, 0.95));
+  border: 1px solid rgba(129, 212, 250, 0.25);
+}
+
+.practice-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.practice-grid article {
+  background: rgba(8, 16, 30, 0.85);
+  border-radius: 18px;
+  padding: 1.5rem 1.75rem;
+  border: 1px solid rgba(79, 195, 247, 0.18);
+  line-height: 1.6;
+}
+
+.panel__footer {
+  margin-top: 2rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+.footer {
+  margin: 3rem auto 2.5rem;
+  text-align: center;
+  color: var(--muted);
+  width: min(900px, 90vw);
+  line-height: 1.6;
+}
+
+@media (max-width: 720px) {
+  .panel {
+    padding: 2.25rem 1.75rem;
+  }
+
+  .hero {
+    padding: 3.5rem 1.25rem 2.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the landing page with a hero banner, navigation, and updated copy tailored for GitHub Pages deployment
- reorganize survival build guidance into concise resource and step cards with new automation, strategy, and practice sections
- refresh the visual style with accessible contrast, skip links, and responsive panel layouts

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7eff2ae90832f94d249c68048f07a