### PR TITLE
Add Hive BedWars strategy guide

### DIFF
--- a/bedwars-strategy.md
+++ b/bedwars-strategy.md
@@ -1,0 +1,35 @@
+# Hive BedWars Basic Strategy (Level 10+)
+
+This straightforward game plan is tuned for players who understand BedWars fundamentals and are at least level 10 on The Hive Bedrock server.
+
+## 1. Opening Minute
+- **Rush iron immediately.** Grab 16 iron, buy 32 wool, and one stone sword. Queue stone sword only if confident; otherwise save for tools.
+- **Bridge to the closest diamond generator.** A quick diagonal bridge keeps pressure while unlocking team upgrades early.
+- **Split resources with teammate.** If playing doubles or squads, share the forge drop before leaving.
+
+## 2. Bed Defense
+- **Layer 1: Wool (8 blocks).** Place a quick wool ring the moment you return.
+- **Layer 2: Endstone or wood.** Buy endstone if the map allows gold quickly; otherwise use wood. Focus on covering corners so TNT or axes take longer to expose.
+- **Trap investment.** Purchase "Alarm" first to prevent invis rushes, then "Counter-Offensive" for quick speed boosts after kills.
+
+## 3. Map Control
+- **Diamonds first, then emeralds.** Secure sharpness and protection upgrades before venturing mid. This gives you an edge in every fight.
+- **Rotate through side islands.** Keep pressure on neighboring teams; break bridges behind you to slow counterattacks.
+- **Collect emeralds in 2-minute cycles.** Leave one teammate mid while the other escorts resources back.
+
+## 4. Offense
+- **Carry shears + pickaxe.** Most beds fall to wool/wood/endstone layers; switching tools speeds the break.
+- **Fireball jumps for final pushes.** Buy at least one fireball for mobility or last-hit potential.
+- **Target stacked teams last.** Eliminate aggressive neighbors first, then collapse on the last turtle team with TNT and pearl combo.
+
+## 5. Late Game & Defense
+- **Rotate armor upgrades.** Iron armor is the baseline. One player should rush diamond armor if emerald income is healthy.
+- **Always leave one person home.** Set a 20-second check-in rule: if no one is at base, someone returns immediately.
+- **Use utilities.** Snowballs, pearls, and knockback boomboxes win clutch fights; keep at least one escape item per player.
+
+## 6. Communication Tips
+- Call out enemy movements (“Yellow bridging mid left side”).
+- Ping upgrade goals so everyone knows whether to hold diamonds or spend.
+- Agree on rush order before the game starts: nearest threat → mid control → final team.
+
+Stick to this structure, adapt to map layouts, and you’ll stabilize your early game and convert more matches into wins.


### PR DESCRIPTION
## Summary
- add a concise strategy guide tailored for level 10+ Hive BedWars players
- outline early-game priorities, bed defense options, map control, offense, and communication tips

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f210aba0832f9d6a2f8b26b12edb